### PR TITLE
Add tiny offset to raw_ts=0 and raise Error on divide by zero

### DIFF
--- a/bmorph/core/bmorph.py
+++ b/bmorph/core/bmorph.py
@@ -12,6 +12,9 @@ sample. The resulting 'bmorph' sample should then be consistent with the
 import pandas as pd
 import scipy.stats
 
+# Done fail silently on divide by zero, but raise an error instead
+pd.np.seterr(divide='raise')
+
 
 def edcdfm(raw_x, raw_cdf, train_cdf, truth_cdf):
     '''Calculate  multipliers using an adapted version of the EDCDFm technique

--- a/scripts/bmorph_tip304
+++ b/scripts/bmorph_tip304
@@ -12,6 +12,10 @@ from bmorph.io import tip304
 
 verbose = False
 
+# define a small value to add when there are 0 values in the input. This value
+# is selected to be smaller than the least significant digit in the input.
+tiny = 1.e-4
+
 
 def main():
     """bmorph a time series from the TIP304 project
@@ -179,6 +183,10 @@ def process_single_file(sitedata, io_info, bmorph_info):
     if verbose:
         print('\tReading {}'.format(infile))
     raw_ts = tip304.get_model_ts(infile)
+    # Add tiny random value to raw_ts values that are 0 to avoid divide by
+    # zero when determining multipliers
+    raw_ts[raw_ts==0] = (tiny *
+        pd.np.random.random_sample([raw_ts[raw_ts==0].size, ]))
     metadata = tip304.get_metadata(infile)
     train_ts = raw_ts.copy()
     nrni_ts = tip304.get_nrni_ts_csv(sitedata['site'], io_info['nrni_file'])


### PR DESCRIPTION
For sites with simulated streamflow values == 0, a divide by zero error would occur under some circumstances when calculating the correction multipliers in `bmorph`: https://github.com/UW-Hydro/bmorph/blob/master/bmorph/core/bmorph.py#L75

The program would only report a warning and then put `-9999` values in the output. This would also result in very large spikes in the outflow, presumably when correcting the annual volumes (not tested that this was the cause).

This PR includes two changes:

1. Change the numpy settings so that an error is raised on divide by zero rather than a warning. This will force the program to stop rather than fail silently.

2. Add a tiny, random offset (with tiny < least significant digit in the input) to simulated streamflow values (`raw_ts`) equal to zero. By only modifying these values it ensures that bias corrections remain unchanged for time series that do not contain zeroes. No offset is added to NRNI 0 values, since these values are the source of the numerator in https://github.com/UW-Hydro/bmorph/blob/master/bmorph/core/bmorph.py#L75 and should not cause a problem.

Testing for three sites (COT, DOR, and TDA) shows that spikes and `-9999` values disappear for the first two locations and that there is no change for TDA (the Dalles). Some further testing is warranted.