### PR TITLE
Feature/fix hruless handling

### DIFF
--- a/bmorph/core/bmorph.py
+++ b/bmorph/core/bmorph.py
@@ -42,6 +42,7 @@ def marginalize_cdf(y_raw, z_raw, vals):
     """Find the marginalized cdf by computing cumsum(P(x|y=val)) for each val"""
     y_raw = np.array(y_raw)
     z_raw = np.array(z_raw)
+    z_raw[z_raw == 0] = 1e-15
     vals = np.array(vals)
     locs = np.argmin(np.abs(vals[:, np.newaxis] - y_raw), axis=1)
     z = np.cumsum(z_raw[:, locs], axis=0)

--- a/bmorph/core/bmorph.py
+++ b/bmorph/core/bmorph.py
@@ -52,7 +52,7 @@ def marginalize_cdf(y_raw, z_raw, vals):
 def cqm(raw_x: pd.Series, train_x: pd.Series, ref_x: pd.Series,
         raw_y: pd.Series, train_y: pd.Series, ref_y: pd.Series=None,
         method='hist', xbins=200, ybins=10, bw=3, rtol=1e-7, atol=0, 
-        nsmooth=5, train_cdf_min=1e-4) -> pd.Series:
+        nsmooth=5, train_cdf_min=1e-6) -> pd.Series:
     """Conditional Quantile Mapping
 
     Multidimensional conditional equidistant CDF matching function:
@@ -98,7 +98,7 @@ def cqm(raw_x: pd.Series, train_x: pd.Series, ref_x: pd.Series,
     return multipliers
 
 
-def edcdfm(raw_x, raw_cdf, train_cdf, ref_cdf, train_cdf_min=1e-4):
+def edcdfm(raw_x, raw_cdf, train_cdf, ref_cdf, train_cdf_min=1e-6):
     '''Calculate  multipliers using an adapted version of the EDCDFm technique
 
     This routine implements part of the PresRat bias correction method from
@@ -171,7 +171,7 @@ def bmorph(raw_ts, train_ts, ref_ts,
            raw_apply_window, raw_train_window, ref_train_window, raw_cdf_window,
            raw_y=None, ref_y=None, train_y=None,
            nsmooth=12, bw=3, xbins=200, ybins=10, rtol=1e-7, atol=0, method='hist',
-           smooth_multipliers=True, train_cdf_min=1e-4):
+           smooth_multipliers=True, train_cdf_min=1e-6):
     '''Morph `raw_ts` based on differences between `ref_ts` and `train_ts`
 
     bmorph is an adaptation of the PresRat bias correction procedure from

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -1,6 +1,3 @@
-import warnings
-warnings.simplefilter(action='ignore', category=FutureWarning)
-
 import bmorph
 import pandas as pd
 import numpy as np

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import xarray as xr
 from functools import partial
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 from bmorph.util import mizuroute_utils as mizutil
 import os
 
@@ -529,11 +529,11 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
             config_dir=bmorph_config['data_path']+'/mizuroute_configs/',
             topo_dir=bmorph_config['data_path']+'/topologies/',
             input_dir=bmorph_config['data_path']+'/input/',
-            output_dir=bmorph_config['data_path']+bmorph_config['output_sub'],
+            output_dir=bmorph_config['data_path']+'/output/',
             )
 
     mizutil.run_mizuroute(mizuroute_exe, config_path)
-    region_totals = xr.open_mfdataset(f'{mizuroute_config["output_dir"]}{bmorph_config["output_prefix"]}_{scbc_type}_scbc*', engine='netcdf4')
+    region_totals = xr.open_mfdataset(f'{mizuroute_config["output_dir"]}{bmorph_config["output_prefix"]}_{scbc_type}_scbc*')
     region_totals = region_totals.sel(time=slice(*bmorph_config['apply_window']))
     region_totals['seg'] = region_totals['reachID'].isel(time=0)
     return region_totals.load()

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -458,12 +458,15 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
         scbc_type = 'univariate'
         scbc_fun = partial(_scbc_u_seg, **bmorph_config)
 
+    # select out segs that have an hru
+    bc_segs_idx = np.where(ds['has_hru'])[0]
+
     if client:
-        futures = [client.submit(scbc_fun, ds.sel(seg=seg)) for seg in ds['seg'].values]
+        futures = [client.submit(scbc_fun, ds.isel(seg=seg)) for seg in bc_segs_idx]
         results = client.gather(futures)
     else:
         results = []
-        for seg in tqdm(ds['seg'].values):
+        for seg in tqdm(bc_segs_idx):
             results.append(scbc_fun(ds.sel(seg=seg)))
 
     out_file = (f'{bmorph_config["data_path"]}/input/'

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import bmorph
 import pandas as pd
 import numpy as np

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -14,7 +14,7 @@ def apply_bmorph(raw_ts, train_ts, ref_ts,
         interval=pd.DateOffset(years=1),
         overlap=60, n_smooth_long=None, n_smooth_short=5,
         bw=3, xbins=200, ybins=10,
-        rtol=1e-6, atol=1e-8, method='hist', train_cdf_min=1e-4, **kwargs):
+        rtol=1e-6, atol=1e-8, method='hist', train_cdf_min=1e-6, **kwargs):
     """Bias correction is performed by bmorph on user-defined intervals.
 
     Parameters
@@ -152,7 +152,7 @@ def apply_blendmorph(raw_upstream_ts, raw_downstream_ts,
                      ref_upstream_y=None, ref_downstream_y=None,
                      n_smooth_long=None, n_smooth_short=5,
                      bw=3, xbins=200, ybins=10, rtol=1e-6, atol=1e-8, 
-                     method='hist', train_cdf_min=1e-4, **kwargs):
+                     method='hist', train_cdf_min=1e-6, **kwargs):
     """Bias correction performed by blending bmorphed flows on user defined intervals.
 
     Blendmorph is used to perform spatially consistent bias correction, this function

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -467,7 +467,7 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
     else:
         results = []
         for seg in tqdm(bc_segs_idx):
-            results.append(scbc_fun(ds.sel(seg=seg)))
+            results.append(scbc_fun(ds.isel(seg=seg)))
 
     out_file = (f'{bmorph_config["data_path"]}/input/'
                 f'{bmorph_config["output_prefix"]}_local_{scbc_type}_scbc.nc')

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -913,6 +913,9 @@ def map_met_hru_to_seg(met_hru, topo):
 
     return met_seg
 
+def check_seg_has_hru():
+
+
 
 def to_bmorph(topo: xr.Dataset, routed: xr.Dataset, reference: xr.Dataset,
                             met_hru: xr.Dataset=None, route_var: str='IRFroutedRunoff',
@@ -1003,5 +1006,13 @@ def to_bmorph(topo: xr.Dataset, routed: xr.Dataset, reference: xr.Dataset,
 
     # Merge it all together
     met_seg = xr.merge([met_seg, routed])
+
+    # Lastly, flag whether each seg has an 
+    # hru or not as a requirement for bias correction
+    hru_2_seg = topo['seg_hru_id'].values
+    met_seg['has_hru'] = np.nan*met_seg['seg']
+    for seg in met_seg['seg'].values:
+        met_seg['has_hru'].loc[{'seg':seg}] = len(np.argwhere(hru_2_seg == seg)) > 0
+
     return met_seg
 

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -132,7 +132,7 @@ def walk_down(ds, start_seg):
     ds: xr.Dataset
         Dataset containing river segments, downstream segs, the length
         of the river segments, and which segs are gauge sites as
-        'seg', 'down_seg', 'lenght', and 'is_gauge', respectively.
+        'seg', 'down_seg', 'length', and 'is_gauge', respectively.
     start_seg: int
         River segment designation to start walking from to a
         downstream gauge site.
@@ -168,7 +168,7 @@ def walk_up(ds, start_seg):
     ds: xr.Dataset
         Dataset containing river segments, upstream segs, the length
         of the river segments, and which segs are gauge sites as
-        'seg', 'up_seg', 'lenght', and 'is_gauge', respectively.
+        'seg', 'up_seg', 'length', and 'is_gauge', respectively.
     start_seg: int
         River segment designation to start walking from to an
         upstream gauge site.

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -913,10 +913,6 @@ def map_met_hru_to_seg(met_hru, topo):
 
     return met_seg
 
-def check_seg_has_hru():
-
-
-
 def to_bmorph(topo: xr.Dataset, routed: xr.Dataset, reference: xr.Dataset,
                             met_hru: xr.Dataset=None, route_var: str='IRFroutedRunoff',
                             fill_method = 'r2', min_kge=None):

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -909,8 +909,8 @@ def map_met_hru_to_seg(met_hru, topo):
             # then we will put nan in its place
             if not len(subset):
                 met_seg[var].loc[{'seg': seg}] = np.nan*met_hru[var].isel(hru=0)
-                warings.warn(f"segement {seg} is not assigned an hru, it will not be bias corrected in bmorph")
-                
+                warnings.warn(f"segement {seg} is not assigned an hru, it will not be bias corrected in bmorph")
+
     return met_seg
 
 

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -908,9 +908,8 @@ def map_met_hru_to_seg(met_hru, topo):
                                     for offset in null_neighborhood])
             # Second fallback, use domain average
             if not len(subset):
-                subset = met_hru['hru'].values
+                subset = np.arange(len(met_hru['hru'].values))
             met_seg[var].loc[{'seg': seg}] = met_hru[var].isel(hru=subset).mean(dim='hru')
-
     return met_seg
 
 

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -1,10 +1,5 @@
 import os
-from glob import glob
-from dask.core import subs
 import xarray as xr
-import pandas as pd
-import geopandas as gpd
-import bmorph
 import numpy as np
 from scipy.stats import entropy
 from string import Template


### PR DESCRIPTION
Addressing the issue https://github.com/UW-Hydro/bmorph/issues/85

`has_hru` has been added as a binary identifier to determine whether or a segment should be bias corrected or not based on if it is assigned an hru or not. Also, if a segment is not assigned an hru, then conditioning data mapped to it is replaced with nans rather than any fallback and a warning is printed.