### PR TITLE
Feature/improve file handling

### DIFF
--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -529,7 +529,6 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
     for optional_config, default in zip(['mizuroute_configs_path', 'topologies_path', 'input_path', 'output_path'], ['/mizuroute_configs/', '/topologies/', '/input/', '/output/']):
         if optional_config not in bmorph_config.keys():
             bmorph_config[optional_config] = bmorph_config['data_path'] + default
-    # for this one we'll let the write_mizroute_config handle the default
     if not 'out_name' in bmorph_config.keys():
         bmorph_config['out_name'] = None
 
@@ -544,7 +543,7 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
             )
 
     mizutil.run_mizuroute(mizuroute_exe, config_path)
-    region_totals = xr.open_mfdataset(f'{mizuroute_config["output_dir"]}{bmorph_config["output_prefix"]}_{scbc_type}_scbc*', engine='netcdf4')
+    region_totals = xr.open_mfdataset(f'{mizuroute_config["output_dir"]}{mizuroute_config["out_name"]}*', engine='netcdf4')
     region_totals = region_totals.sel(time=slice(*bmorph_config['apply_window']))
     region_totals['seg'] = region_totals['reachID'].isel(time=0)
     return region_totals.load()

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -523,13 +523,24 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
     else:
         mult_file = None
     unpack_and_write_netcdf(results, ds['seg'], out_file, mult_path=mult_file)
+    
+    # need to set our optional directory configs to their default
+    # in case they were not specified
+    for optional_config, default in zip(['mizuroute_configs_path', 'topologies_path', 'input_path', 'output_path'], ['/mizuroute_configs/', '/topologies/', '/input/', '/output/']):
+        if optional_config not in bmorph_config.keys():
+            bmorph_config[optional_config] = bmorph_config['data_path'] + default
+    # for this one we'll let the write_mizroute_config handle the default
+    if not 'out_name' in bmorph_config.keys():
+        bmorph_config['out_name'] = None
+
     config_path, mizuroute_config = mizutil.write_mizuroute_config(
             bmorph_config["output_prefix"],
             scbc_type, bmorph_config['apply_window'],
-            config_dir=bmorph_config['data_path']+'/mizuroute_configs/',
-            topo_dir=bmorph_config['data_path']+'/topologies/',
-            input_dir=bmorph_config['data_path']+'/input/',
-            output_dir=bmorph_config['data_path']+bmorph_config['output_sub'],
+            config_dir=bmorph_config['mizuroute_configs_path'],
+            topo_dir=bmorph_config['topologies_path'],
+            input_dir=bmorph_config['input_path'],
+            output_dir=bmorph_config['output_path'],
+            out_name=bmorph_config['out_name']
             )
 
     mizutil.run_mizuroute(mizuroute_exe, config_path)

--- a/bmorph/core/workflows.py
+++ b/bmorph/core/workflows.py
@@ -523,23 +523,15 @@ def apply_scbc(ds, mizuroute_exe, bmorph_config, client=None, save_mults=False):
     else:
         mult_file = None
     unpack_and_write_netcdf(results, ds['seg'], out_file, mult_path=mult_file)
-    
-    # need to set our optional directory configs to their default
-    # in case they were not specified
-    for optional_config, default in zip(['mizuroute_configs_path', 'topologies_path', 'input_path', 'output_path'], ['/mizuroute_configs/', '/topologies/', '/input/', '/output/']):
-        if optional_config not in bmorph_config.keys():
-            bmorph_config[optional_config] = bmorph_config['data_path'] + default
-    if not 'out_name' in bmorph_config.keys():
-        bmorph_config['out_name'] = None
 
     config_path, mizuroute_config = mizutil.write_mizuroute_config(
             bmorph_config["output_prefix"],
             scbc_type, bmorph_config['apply_window'],
-            config_dir=bmorph_config['mizuroute_configs_path'],
-            topo_dir=bmorph_config['topologies_path'],
-            input_dir=bmorph_config['input_path'],
-            output_dir=bmorph_config['output_path'],
-            out_name=bmorph_config['out_name']
+            config_dir=bmorph_config.get('mizuroute_configs_path', bmorph_config['data_path'] + '/mizuroute_configs/'),
+            topo_dir=bmorph_config.get('topologies_path', bmorph_config['data_path'] + '/topologies/'),
+            input_dir=bmorph_config.get('input_path', bmorph_config['data_path'] + '/input/'),
+            output_dir=bmorph_config.get('output_path', bmorph_config['data_path'] + '/output/'),
+            out_name=bmorph_config.get('out_name', None)
             )
 
     mizutil.run_mizuroute(mizuroute_exe, config_path)

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -48,7 +48,13 @@ def write_mizuroute_config(region, scbc_type, time_window,
                            config_dir='../mizuroute_configs/',
                            topo_dir='../topologies/',
                            input_dir='../input/',
-                           output_dir='../output/'):
+                           output_dir='../output/',
+                           out_name=None):
+    # meaning an out_name was not specified and we should
+    # specify it here
+    if not out_name:
+        out_name = f'{region}_{scbc_type}_scbc'
+
     mizuroute_config = {
         'ancil_dir': os.path.abspath(topo_dir)+'/',
         'input_dir': os.path.abspath(input_dir)+'/',
@@ -57,7 +63,7 @@ def write_mizuroute_config(region, scbc_type, time_window,
         'sim_end': time_window[1].strftime("%Y-%m-%d"),
         'topo_file': f'{region}_huc12_topology_scaled_area.nc',
         'flow_file': f'{region}_local_{scbc_type}_scbc.nc',
-        'out_name': f'{region}_{scbc_type}_scbc'
+        'out_name': out_name
     }
 
     config_path = os.path.abspath(f'{config_dir}reroute_{region}_{scbc_type}.control')

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -380,7 +380,7 @@ def trim_time(dataset_list: list):
 
 def map_segs_topology(routed: xr.Dataset, topology: xr.Dataset):
     """
-    Adds contributing_area, average elevation, length, and down_seg to
+    Adds contributing_area, length, and down_seg to
     routed from topology.
 
     Parameters
@@ -400,7 +400,6 @@ def map_segs_topology(routed: xr.Dataset, topology: xr.Dataset):
     """
     routed = routed.sel(seg=topology['seg'])
     routed['contributing_area'] = topology['Contrib_Area']
-    #routed['elevation'] = 0.5 * (topology['TopElev'] + topology['BotElev'])
     routed['length'] = topology['Length']
     routed['down_seg'] = topology['Tosegment']
 

--- a/bmorph/util/mizuroute_utils.py
+++ b/bmorph/util/mizuroute_utils.py
@@ -399,7 +399,7 @@ def map_segs_topology(routed: xr.Dataset, topology: xr.Dataset):
         The input dataset routed updated with the topological data.
     """
     routed = routed.sel(seg=topology['seg'])
-    #routed['contributing_area'] = topology['Contrib_Area']
+    routed['contributing_area'] = topology['Contrib_Area']
     #routed['elevation'] = 0.5 * (topology['TopElev'] + topology['BotElev'])
     routed['length'] = topology['Length']
     routed['down_seg'] = topology['Tosegment']


### PR DESCRIPTION
Allows for user specification of each directory used in bmorph (configs, topos, input, output) and what the file name of the mizuRoute's outputs are as well. This will reduce possibility of file corruption from overwriting files. The default option described in the tutorial still exists and specifying each directory is optional. 